### PR TITLE
Additions to aadlba.ecore to ease visit and manipulations

### DIFF
--- a/org.osate.ba.edit/plugin.properties
+++ b/org.osate.ba.edit/plugin.properties
@@ -339,3 +339,4 @@ _UI_UnaryNumericOperator_None_literal =
 _UI_UnaryNumericOperator_Abs_literal = abs
 _UI_BehaviorState_incomingTransitions_feature = Incoming Transitions
 _UI_BehaviorState_outgoingTransitions_feature = Outgoing Transitions
+_UI_BehaviorAnnex_initialState_feature = Initial State

--- a/org.osate.ba.edit/plugin.properties
+++ b/org.osate.ba.edit/plugin.properties
@@ -337,3 +337,5 @@ _UI_UnaryBooleanOperator_None_literal =
 _UI_UnaryBooleanOperator_Not_literal = !
 _UI_UnaryNumericOperator_None_literal = 
 _UI_UnaryNumericOperator_Abs_literal = abs
+_UI_BehaviorState_incomingTransitions_feature = Incoming Transitions
+_UI_BehaviorState_outgoingTransitions_feature = Outgoing Transitions

--- a/org.osate.ba.edit/src/org/osate/ba/aadlba/provider/BehaviorAnnexItemProvider.java
+++ b/org.osate.ba.edit/src/org/osate/ba/aadlba/provider/BehaviorAnnexItemProvider.java
@@ -28,6 +28,7 @@ import org.eclipse.emf.common.notify.AdapterFactory ;
 import org.eclipse.emf.common.notify.Notification ;
 import org.eclipse.emf.common.util.ResourceLocator ;
 import org.eclipse.emf.ecore.EStructuralFeature ;
+import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor ;
 import org.eclipse.emf.edit.provider.ViewerNotification ;
 import org.osate.aadl2.provider.AnnexSubclauseItemProvider ;
@@ -68,8 +69,32 @@ public class BehaviorAnnexItemProvider
     {
       super.getPropertyDescriptors(object);
 
+      addInitialStatePropertyDescriptor(object);
     }
     return itemPropertyDescriptors;
+  }
+
+  /**
+   * This adds a property descriptor for the Initial State feature.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  protected void addInitialStatePropertyDescriptor(Object object)
+  {
+    itemPropertyDescriptors.add
+      (createItemPropertyDescriptor
+        (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+         getResourceLocator(),
+         getString("_UI_BehaviorAnnex_initialState_feature"),
+         getString("_UI_PropertyDescriptor_description", "_UI_BehaviorAnnex_initialState_feature", "_UI_BehaviorAnnex_type"),
+         AadlBaPackage.Literals.BEHAVIOR_ANNEX__INITIAL_STATE,
+         true,
+         false,
+         true,
+         null,
+         null,
+         null));
   }
 
   /**

--- a/org.osate.ba.edit/src/org/osate/ba/aadlba/provider/BehaviorStateItemProvider.java
+++ b/org.osate.ba.edit/src/org/osate/ba/aadlba/provider/BehaviorStateItemProvider.java
@@ -70,6 +70,8 @@ public class BehaviorStateItemProvider
       addCompletePropertyDescriptor(object);
       addFinalPropertyDescriptor(object);
       addBindedModePropertyDescriptor(object);
+      addIncomingTransitionsPropertyDescriptor(object);
+      addOutgoingTransitionsPropertyDescriptor(object);
     }
     return itemPropertyDescriptors;
   }
@@ -158,6 +160,52 @@ public class BehaviorStateItemProvider
          getString("_UI_BehaviorState_bindedMode_feature"),
          getString("_UI_PropertyDescriptor_description", "_UI_BehaviorState_bindedMode_feature", "_UI_BehaviorState_type"),
          AadlBaPackage.Literals.BEHAVIOR_STATE__BINDED_MODE,
+         true,
+         false,
+         true,
+         null,
+         null,
+         null));
+  }
+
+  /**
+   * This adds a property descriptor for the Incoming Transitions feature.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  protected void addIncomingTransitionsPropertyDescriptor(Object object)
+  {
+    itemPropertyDescriptors.add
+      (createItemPropertyDescriptor
+        (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+         getResourceLocator(),
+         getString("_UI_BehaviorState_incomingTransitions_feature"),
+         getString("_UI_PropertyDescriptor_description", "_UI_BehaviorState_incomingTransitions_feature", "_UI_BehaviorState_type"),
+         AadlBaPackage.Literals.BEHAVIOR_STATE__INCOMING_TRANSITIONS,
+         true,
+         false,
+         true,
+         null,
+         null,
+         null));
+  }
+
+  /**
+   * This adds a property descriptor for the Outgoing Transitions feature.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  protected void addOutgoingTransitionsPropertyDescriptor(Object object)
+  {
+    itemPropertyDescriptors.add
+      (createItemPropertyDescriptor
+        (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+         getResourceLocator(),
+         getString("_UI_BehaviorState_outgoingTransitions_feature"),
+         getString("_UI_PropertyDescriptor_description", "_UI_BehaviorState_outgoingTransitions_feature", "_UI_BehaviorState_type"),
+         AadlBaPackage.Literals.BEHAVIOR_STATE__OUTGOING_TRANSITIONS,
          true,
          false,
          true,

--- a/org.osate.ba/model/aadlba.ecore
+++ b/org.osate.ba/model/aadlba.ecore
@@ -65,6 +65,8 @@
         eType="#//BehaviorActionBlock" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="conditions" upperBound="-1"
         eType="#//BehaviorCondition" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="initialState" lowerBound="1"
+        eType="#//BehaviorState"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="BehaviorBooleanLiteral" eSuperTypes="../../org.osate.aadl2/model/aadl2.ecore#//BooleanLiteral #//Literal"/>
   <eClassifiers xsi:type="ecore:EClass" name="BehaviorCondition" abstract="true" interface="true"

--- a/org.osate.ba/model/aadlba.ecore
+++ b/org.osate.ba/model/aadlba.ecore
@@ -102,6 +102,10 @@
         defaultValueLiteral="false"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="bindedMode" unique="false"
         eType="ecore:EClass ../../org.osate.aadl2/model/aadl2.ecore#//Mode"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="incomingTransitions" upperBound="-1"
+        eType="#//BehaviorTransition" eOpposite="#//BehaviorTransition/destinationState"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="outgoingTransitions" upperBound="-1"
+        eType="#//BehaviorTransition" eOpposite="#//BehaviorTransition/sourceState"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="BehaviorStringLiteral" eSuperTypes="../../org.osate.aadl2/model/aadl2.ecore#//StringLiteral #//Literal"/>
   <eClassifiers xsi:type="ecore:EClass" name="BehaviorTime" eSuperTypes="#//BehaviorElement">
@@ -111,11 +115,11 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="BehaviorTransition" eSuperTypes="#//BehaviorNamedElement">
     <eStructuralFeatures xsi:type="ecore:EReference" name="sourceState" unique="false"
-        eType="#//BehaviorState"/>
+        eType="#//BehaviorState" eOpposite="#//BehaviorState/outgoingTransitions"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="condition" unique="false"
         eType="#//BehaviorCondition" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="destinationState" unique="false"
-        eType="#//BehaviorState"/>
+        eType="#//BehaviorState" eOpposite="#//BehaviorState/incomingTransitions"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="actionBlock" unique="false"
         eType="#//BehaviorActionBlock"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="priority" unique="false"

--- a/org.osate.ba/src/org/osate/ba/aadlba/AadlBaPackage.java
+++ b/org.osate.ba/src/org/osate/ba/aadlba/AadlBaPackage.java
@@ -1805,13 +1805,22 @@ public interface AadlBaPackage extends EPackage
   int BEHAVIOR_ANNEX__CONDITIONS = Aadl2Package.ANNEX_SUBCLAUSE_FEATURE_COUNT + 4;
 
   /**
+   * The feature id for the '<em><b>Initial State</b></em>' reference.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int BEHAVIOR_ANNEX__INITIAL_STATE = Aadl2Package.ANNEX_SUBCLAUSE_FEATURE_COUNT + 5;
+
+  /**
    * The number of structural features of the '<em>Behavior Annex</em>' class.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
    * @generated
    * @ordered
    */
-  int BEHAVIOR_ANNEX_FEATURE_COUNT = Aadl2Package.ANNEX_SUBCLAUSE_FEATURE_COUNT + 5;
+  int BEHAVIOR_ANNEX_FEATURE_COUNT = Aadl2Package.ANNEX_SUBCLAUSE_FEATURE_COUNT + 6;
 
   /**
    * The feature id for the '<em><b>Owned Element</b></em>' reference list.
@@ -6727,6 +6736,17 @@ public interface AadlBaPackage extends EPackage
   EReference getBehaviorAnnex_Conditions();
 
   /**
+   * Returns the meta object for the reference '{@link org.osate.ba.aadlba.BehaviorAnnex#getInitialState <em>Initial State</em>}'.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @return the meta object for the reference '<em>Initial State</em>'.
+   * @see org.osate.ba.aadlba.BehaviorAnnex#getInitialState()
+   * @see #getBehaviorAnnex()
+   * @generated
+   */
+  EReference getBehaviorAnnex_InitialState();
+
+  /**
    * Returns the meta object for class '{@link org.osate.ba.aadlba.BehaviorBooleanLiteral <em>Behavior Boolean Literal</em>}'.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
@@ -8925,6 +8945,14 @@ public interface AadlBaPackage extends EPackage
      * @generated
      */
     EReference BEHAVIOR_ANNEX__CONDITIONS = eINSTANCE.getBehaviorAnnex_Conditions();
+
+    /**
+     * The meta object literal for the '<em><b>Initial State</b></em>' reference feature.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    EReference BEHAVIOR_ANNEX__INITIAL_STATE = eINSTANCE.getBehaviorAnnex_InitialState();
 
     /**
      * The meta object literal for the '{@link org.osate.ba.aadlba.impl.BehaviorBooleanLiteralImpl <em>Behavior Boolean Literal</em>}' class.

--- a/org.osate.ba/src/org/osate/ba/aadlba/AadlBaPackage.java
+++ b/org.osate.ba/src/org/osate/ba/aadlba/AadlBaPackage.java
@@ -469,7 +469,7 @@ public interface AadlBaPackage extends EPackage
    * @see org.osate.ba.aadlba.impl.AadlBaPackageImpl#getCommunicationAction()
    * @generated
    */
-  int COMMUNICATION_ACTION = 28;
+  int COMMUNICATION_ACTION = 29;
 
   /**
    * The meta object id for the '{@link org.osate.ba.aadlba.impl.CompletionRelativeTimeoutImpl <em>Completion Relative Timeout</em>}' class.
@@ -479,7 +479,7 @@ public interface AadlBaPackage extends EPackage
    * @see org.osate.ba.aadlba.impl.AadlBaPackageImpl#getCompletionRelativeTimeout()
    * @generated
    */
-  int COMPLETION_RELATIVE_TIMEOUT = 29;
+  int COMPLETION_RELATIVE_TIMEOUT = 30;
 
   /**
    * The meta object id for the '{@link org.osate.ba.aadlba.CondStatement <em>Cond Statement</em>}' class.
@@ -1450,7 +1450,7 @@ public interface AadlBaPackage extends EPackage
    * @see org.osate.ba.aadlba.impl.AadlBaPackageImpl#getPropertyElementHolder()
    * @generated
    */
-  int PROPERTY_ELEMENT_HOLDER = 86;
+  int PROPERTY_ELEMENT_HOLDER = 85;
 
   /**
    * The feature id for the '<em><b>Owned Element</b></em>' reference list.
@@ -2183,13 +2183,31 @@ public interface AadlBaPackage extends EPackage
   int BEHAVIOR_STATE__BINDED_MODE = BEHAVIOR_NAMED_ELEMENT_FEATURE_COUNT + 3;
 
   /**
+   * The feature id for the '<em><b>Incoming Transitions</b></em>' reference list.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int BEHAVIOR_STATE__INCOMING_TRANSITIONS = BEHAVIOR_NAMED_ELEMENT_FEATURE_COUNT + 4;
+
+  /**
+   * The feature id for the '<em><b>Outgoing Transitions</b></em>' reference list.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int BEHAVIOR_STATE__OUTGOING_TRANSITIONS = BEHAVIOR_NAMED_ELEMENT_FEATURE_COUNT + 5;
+
+  /**
    * The number of structural features of the '<em>Behavior State</em>' class.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
    * @generated
    * @ordered
    */
-  int BEHAVIOR_STATE_FEATURE_COUNT = BEHAVIOR_NAMED_ELEMENT_FEATURE_COUNT + 4;
+  int BEHAVIOR_STATE_FEATURE_COUNT = BEHAVIOR_NAMED_ELEMENT_FEATURE_COUNT + 6;
 
   /**
    * The feature id for the '<em><b>Owned Element</b></em>' reference list.
@@ -2678,7 +2696,7 @@ public interface AadlBaPackage extends EPackage
    * @see org.osate.ba.aadlba.impl.AadlBaPackageImpl#getPropertyReference()
    * @generated
    */
-  int PROPERTY_REFERENCE = 90;
+  int PROPERTY_REFERENCE = 89;
 
   /**
    * The feature id for the '<em><b>Owned Element</b></em>' reference list.
@@ -2724,7 +2742,7 @@ public interface AadlBaPackage extends EPackage
    * @see org.osate.ba.aadlba.impl.AadlBaPackageImpl#getPropertySetPropertyReference()
    * @generated
    */
-  int PROPERTY_SET_PROPERTY_REFERENCE = 91;
+  int PROPERTY_SET_PROPERTY_REFERENCE = 90;
 
   /**
    * The meta object id for the '{@link org.osate.ba.aadlba.impl.SubcomponentHolderImpl <em>Subcomponent Holder</em>}' class.
@@ -2764,7 +2782,62 @@ public interface AadlBaPackage extends EPackage
    * @see org.osate.ba.aadlba.impl.AadlBaPackageImpl#getClassifierPropertyReference()
    * @generated
    */
-  int CLASSIFIER_PROPERTY_REFERENCE = 27;
+  int CLASSIFIER_PROPERTY_REFERENCE = 28;
+
+  /**
+   * The meta object id for the '{@link org.osate.ba.aadlba.impl.ClassifierFeaturePropertyReferenceImpl <em>Classifier Feature Property Reference</em>}' class.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see org.osate.ba.aadlba.impl.ClassifierFeaturePropertyReferenceImpl
+   * @see org.osate.ba.aadlba.impl.AadlBaPackageImpl#getClassifierFeaturePropertyReference()
+   * @generated
+   */
+  int CLASSIFIER_FEATURE_PROPERTY_REFERENCE = 27;
+
+  /**
+   * The feature id for the '<em><b>Owned Element</b></em>' reference list.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int CLASSIFIER_FEATURE_PROPERTY_REFERENCE__OWNED_ELEMENT = PROPERTY_REFERENCE__OWNED_ELEMENT;
+
+  /**
+   * The feature id for the '<em><b>Owned Comment</b></em>' containment reference list.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int CLASSIFIER_FEATURE_PROPERTY_REFERENCE__OWNED_COMMENT = PROPERTY_REFERENCE__OWNED_COMMENT;
+
+  /**
+   * The feature id for the '<em><b>Properties</b></em>' containment reference list.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int CLASSIFIER_FEATURE_PROPERTY_REFERENCE__PROPERTIES = PROPERTY_REFERENCE__PROPERTIES;
+
+  /**
+   * The feature id for the '<em><b>Component</b></em>' containment reference.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int CLASSIFIER_FEATURE_PROPERTY_REFERENCE__COMPONENT = PROPERTY_REFERENCE_FEATURE_COUNT + 0;
+
+  /**
+   * The number of structural features of the '<em>Classifier Feature Property Reference</em>' class.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int CLASSIFIER_FEATURE_PROPERTY_REFERENCE_FEATURE_COUNT = PROPERTY_REFERENCE_FEATURE_COUNT + 1;
 
   /**
    * The feature id for the '<em><b>Owned Element</b></em>' reference list.
@@ -2882,61 +2955,6 @@ public interface AadlBaPackage extends EPackage
    * @ordered
    */
   int COMPLETION_RELATIVE_TIMEOUT_FEATURE_COUNT = BEHAVIOR_TIME_FEATURE_COUNT + 0;
-
-  /**
-   * The meta object id for the '{@link org.osate.ba.aadlba.impl.ClassifierFeaturePropertyReferenceImpl <em>Classifier Feature Property Reference</em>}' class.
-   * <!-- begin-user-doc -->
-   * <!-- end-user-doc -->
-   * @see org.osate.ba.aadlba.impl.ClassifierFeaturePropertyReferenceImpl
-   * @see org.osate.ba.aadlba.impl.AadlBaPackageImpl#getClassifierFeaturePropertyReference()
-   * @generated
-   */
-  int CLASSIFIER_FEATURE_PROPERTY_REFERENCE = 30;
-
-  /**
-   * The feature id for the '<em><b>Owned Element</b></em>' reference list.
-   * <!-- begin-user-doc -->
-   * <!-- end-user-doc -->
-   * @generated
-   * @ordered
-   */
-  int CLASSIFIER_FEATURE_PROPERTY_REFERENCE__OWNED_ELEMENT = PROPERTY_REFERENCE__OWNED_ELEMENT;
-
-  /**
-   * The feature id for the '<em><b>Owned Comment</b></em>' containment reference list.
-   * <!-- begin-user-doc -->
-   * <!-- end-user-doc -->
-   * @generated
-   * @ordered
-   */
-  int CLASSIFIER_FEATURE_PROPERTY_REFERENCE__OWNED_COMMENT = PROPERTY_REFERENCE__OWNED_COMMENT;
-
-  /**
-   * The feature id for the '<em><b>Properties</b></em>' containment reference list.
-   * <!-- begin-user-doc -->
-   * <!-- end-user-doc -->
-   * @generated
-   * @ordered
-   */
-  int CLASSIFIER_FEATURE_PROPERTY_REFERENCE__PROPERTIES = PROPERTY_REFERENCE__PROPERTIES;
-
-  /**
-   * The feature id for the '<em><b>Component</b></em>' containment reference.
-   * <!-- begin-user-doc -->
-   * <!-- end-user-doc -->
-   * @generated
-   * @ordered
-   */
-  int CLASSIFIER_FEATURE_PROPERTY_REFERENCE__COMPONENT = PROPERTY_REFERENCE_FEATURE_COUNT + 0;
-
-  /**
-   * The number of structural features of the '<em>Classifier Feature Property Reference</em>' class.
-   * <!-- begin-user-doc -->
-   * <!-- end-user-doc -->
-   * @generated
-   * @ordered
-   */
-  int CLASSIFIER_FEATURE_PROPERTY_REFERENCE_FEATURE_COUNT = PROPERTY_REFERENCE_FEATURE_COUNT + 1;
 
   /**
    * The feature id for the '<em><b>Owned Element</b></em>' reference list.
@@ -4594,7 +4612,7 @@ public interface AadlBaPackage extends EPackage
    * @see org.osate.ba.aadlba.impl.AadlBaPackageImpl#getPropertyNameField()
    * @generated
    */
-  int PROPERTY_NAME_FIELD = 84;
+  int PROPERTY_NAME_FIELD = 87;
 
   /**
    * The feature id for the '<em><b>Owned Element</b></em>' reference list.
@@ -5191,52 +5209,7 @@ public interface AadlBaPackage extends EPackage
    * @see org.osate.ba.aadlba.impl.AadlBaPackageImpl#getPropertyNameHolder()
    * @generated
    */
-  int PROPERTY_NAME_HOLDER = 85;
-
-  /**
-   * The feature id for the '<em><b>Owned Element</b></em>' reference list.
-   * <!-- begin-user-doc -->
-   * <!-- end-user-doc -->
-   * @generated
-   * @ordered
-   */
-  int PROPERTY_NAME_HOLDER__OWNED_ELEMENT = BEHAVIOR_ELEMENT__OWNED_ELEMENT;
-
-  /**
-   * The feature id for the '<em><b>Owned Comment</b></em>' containment reference list.
-   * <!-- begin-user-doc -->
-   * <!-- end-user-doc -->
-   * @generated
-   * @ordered
-   */
-  int PROPERTY_NAME_HOLDER__OWNED_COMMENT = BEHAVIOR_ELEMENT__OWNED_COMMENT;
-
-  /**
-   * The feature id for the '<em><b>Property</b></em>' containment reference.
-   * <!-- begin-user-doc -->
-   * <!-- end-user-doc -->
-   * @generated
-   * @ordered
-   */
-  int PROPERTY_NAME_HOLDER__PROPERTY = BEHAVIOR_ELEMENT_FEATURE_COUNT + 0;
-
-  /**
-   * The feature id for the '<em><b>Field</b></em>' containment reference.
-   * <!-- begin-user-doc -->
-   * <!-- end-user-doc -->
-   * @generated
-   * @ordered
-   */
-  int PROPERTY_NAME_HOLDER__FIELD = BEHAVIOR_ELEMENT_FEATURE_COUNT + 1;
-
-  /**
-   * The number of structural features of the '<em>Property Name Holder</em>' class.
-   * <!-- begin-user-doc -->
-   * <!-- end-user-doc -->
-   * @generated
-   * @ordered
-   */
-  int PROPERTY_NAME_HOLDER_FEATURE_COUNT = BEHAVIOR_ELEMENT_FEATURE_COUNT + 2;
+  int PROPERTY_NAME_HOLDER = 88;
 
   /**
    * The meta object id for the '{@link org.osate.ba.aadlba.impl.PropertyAssociationHolderImpl <em>Property Association Holder</em>}' class.
@@ -5246,7 +5219,7 @@ public interface AadlBaPackage extends EPackage
    * @see org.osate.ba.aadlba.impl.AadlBaPackageImpl#getPropertyAssociationHolder()
    * @generated
    */
-  int PROPERTY_ASSOCIATION_HOLDER = 87;
+  int PROPERTY_ASSOCIATION_HOLDER = 84;
 
   /**
    * The feature id for the '<em><b>Owned Element</b></em>' reference list.
@@ -5301,7 +5274,7 @@ public interface AadlBaPackage extends EPackage
    * @see org.osate.ba.aadlba.impl.AadlBaPackageImpl#getPropertyExpressionHolder()
    * @generated
    */
-  int PROPERTY_EXPRESSION_HOLDER = 88;
+  int PROPERTY_EXPRESSION_HOLDER = 86;
 
   /**
    * The feature id for the '<em><b>Owned Element</b></em>' reference list.
@@ -5349,23 +5322,13 @@ public interface AadlBaPackage extends EPackage
   int PROPERTY_EXPRESSION_HOLDER_FEATURE_COUNT = PROPERTY_ELEMENT_HOLDER_FEATURE_COUNT + 0;
 
   /**
-   * The meta object id for the '{@link org.osate.ba.aadlba.impl.PropertyTypeHolderImpl <em>Property Type Holder</em>}' class.
-   * <!-- begin-user-doc -->
-   * <!-- end-user-doc -->
-   * @see org.osate.ba.aadlba.impl.PropertyTypeHolderImpl
-   * @see org.osate.ba.aadlba.impl.AadlBaPackageImpl#getPropertyTypeHolder()
-   * @generated
-   */
-  int PROPERTY_TYPE_HOLDER = 89;
-
-  /**
    * The feature id for the '<em><b>Owned Element</b></em>' reference list.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
    * @generated
    * @ordered
    */
-  int PROPERTY_TYPE_HOLDER__OWNED_ELEMENT = PROPERTY_ELEMENT_HOLDER__OWNED_ELEMENT;
+  int PROPERTY_NAME_HOLDER__OWNED_ELEMENT = BEHAVIOR_ELEMENT__OWNED_ELEMENT;
 
   /**
    * The feature id for the '<em><b>Owned Comment</b></em>' containment reference list.
@@ -5374,34 +5337,44 @@ public interface AadlBaPackage extends EPackage
    * @generated
    * @ordered
    */
-  int PROPERTY_TYPE_HOLDER__OWNED_COMMENT = PROPERTY_ELEMENT_HOLDER__OWNED_COMMENT;
+  int PROPERTY_NAME_HOLDER__OWNED_COMMENT = BEHAVIOR_ELEMENT__OWNED_COMMENT;
 
   /**
-   * The feature id for the '<em><b>Array Indexes</b></em>' containment reference list.
+   * The feature id for the '<em><b>Property</b></em>' containment reference.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
    * @generated
    * @ordered
    */
-  int PROPERTY_TYPE_HOLDER__ARRAY_INDEXES = PROPERTY_ELEMENT_HOLDER__ARRAY_INDEXES;
+  int PROPERTY_NAME_HOLDER__PROPERTY = BEHAVIOR_ELEMENT_FEATURE_COUNT + 0;
 
   /**
-   * The feature id for the '<em><b>Element</b></em>' reference.
+   * The feature id for the '<em><b>Field</b></em>' containment reference.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
    * @generated
    * @ordered
    */
-  int PROPERTY_TYPE_HOLDER__ELEMENT = PROPERTY_ELEMENT_HOLDER__ELEMENT;
+  int PROPERTY_NAME_HOLDER__FIELD = BEHAVIOR_ELEMENT_FEATURE_COUNT + 1;
 
   /**
-   * The number of structural features of the '<em>Property Type Holder</em>' class.
+   * The number of structural features of the '<em>Property Name Holder</em>' class.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
    * @generated
    * @ordered
    */
-  int PROPERTY_TYPE_HOLDER_FEATURE_COUNT = PROPERTY_ELEMENT_HOLDER_FEATURE_COUNT + 0;
+  int PROPERTY_NAME_HOLDER_FEATURE_COUNT = BEHAVIOR_ELEMENT_FEATURE_COUNT + 2;
+
+  /**
+   * The meta object id for the '{@link org.osate.ba.aadlba.impl.PropertyTypeHolderImpl <em>Property Type Holder</em>}' class.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see org.osate.ba.aadlba.impl.PropertyTypeHolderImpl
+   * @see org.osate.ba.aadlba.impl.AadlBaPackageImpl#getPropertyTypeHolder()
+   * @generated
+   */
+  int PROPERTY_TYPE_HOLDER = 91;
 
   /**
    * The feature id for the '<em><b>Owned Element</b></em>' reference list.
@@ -5447,6 +5420,51 @@ public interface AadlBaPackage extends EPackage
    * @ordered
    */
   int PROPERTY_SET_PROPERTY_REFERENCE_FEATURE_COUNT = PROPERTY_REFERENCE_FEATURE_COUNT + 1;
+
+  /**
+   * The feature id for the '<em><b>Owned Element</b></em>' reference list.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int PROPERTY_TYPE_HOLDER__OWNED_ELEMENT = PROPERTY_ELEMENT_HOLDER__OWNED_ELEMENT;
+
+  /**
+   * The feature id for the '<em><b>Owned Comment</b></em>' containment reference list.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int PROPERTY_TYPE_HOLDER__OWNED_COMMENT = PROPERTY_ELEMENT_HOLDER__OWNED_COMMENT;
+
+  /**
+   * The feature id for the '<em><b>Array Indexes</b></em>' containment reference list.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int PROPERTY_TYPE_HOLDER__ARRAY_INDEXES = PROPERTY_ELEMENT_HOLDER__ARRAY_INDEXES;
+
+  /**
+   * The feature id for the '<em><b>Element</b></em>' reference.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int PROPERTY_TYPE_HOLDER__ELEMENT = PROPERTY_ELEMENT_HOLDER__ELEMENT;
+
+  /**
+   * The number of structural features of the '<em>Property Type Holder</em>' class.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int PROPERTY_TYPE_HOLDER_FEATURE_COUNT = PROPERTY_ELEMENT_HOLDER_FEATURE_COUNT + 0;
 
   /**
    * The feature id for the '<em><b>Owned Element</b></em>' reference list.
@@ -6853,6 +6871,28 @@ public interface AadlBaPackage extends EPackage
    * @generated
    */
   EReference getBehaviorState_BindedMode();
+
+  /**
+   * Returns the meta object for the reference list '{@link org.osate.ba.aadlba.BehaviorState#getIncomingTransitions <em>Incoming Transitions</em>}'.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @return the meta object for the reference list '<em>Incoming Transitions</em>'.
+   * @see org.osate.ba.aadlba.BehaviorState#getIncomingTransitions()
+   * @see #getBehaviorState()
+   * @generated
+   */
+  EReference getBehaviorState_IncomingTransitions();
+
+  /**
+   * Returns the meta object for the reference list '{@link org.osate.ba.aadlba.BehaviorState#getOutgoingTransitions <em>Outgoing Transitions</em>}'.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @return the meta object for the reference list '<em>Outgoing Transitions</em>'.
+   * @see org.osate.ba.aadlba.BehaviorState#getOutgoingTransitions()
+   * @see #getBehaviorState()
+   * @generated
+   */
+  EReference getBehaviorState_OutgoingTransitions();
 
   /**
    * Returns the meta object for class '{@link org.osate.ba.aadlba.BehaviorStringLiteral <em>Behavior String Literal</em>}'.
@@ -9013,6 +9053,22 @@ public interface AadlBaPackage extends EPackage
      * @generated
      */
     EReference BEHAVIOR_STATE__BINDED_MODE = eINSTANCE.getBehaviorState_BindedMode();
+
+    /**
+     * The meta object literal for the '<em><b>Incoming Transitions</b></em>' reference list feature.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    EReference BEHAVIOR_STATE__INCOMING_TRANSITIONS = eINSTANCE.getBehaviorState_IncomingTransitions();
+
+    /**
+     * The meta object literal for the '<em><b>Outgoing Transitions</b></em>' reference list feature.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    EReference BEHAVIOR_STATE__OUTGOING_TRANSITIONS = eINSTANCE.getBehaviorState_OutgoingTransitions();
 
     /**
      * The meta object literal for the '{@link org.osate.ba.aadlba.impl.BehaviorStringLiteralImpl <em>Behavior String Literal</em>}' class.

--- a/org.osate.ba/src/org/osate/ba/aadlba/BehaviorAnnex.java
+++ b/org.osate.ba/src/org/osate/ba/aadlba/BehaviorAnnex.java
@@ -41,6 +41,7 @@ import org.osate.ba.utils.AadlBaLocationReference ;
  *   <li>{@link org.osate.ba.aadlba.BehaviorAnnex#getTransitions <em>Transitions</em>}</li>
  *   <li>{@link org.osate.ba.aadlba.BehaviorAnnex#getActions <em>Actions</em>}</li>
  *   <li>{@link org.osate.ba.aadlba.BehaviorAnnex#getConditions <em>Conditions</em>}</li>
+ *   <li>{@link org.osate.ba.aadlba.BehaviorAnnex#getInitialState <em>Initial State</em>}</li>
  * </ul>
  * </p>
  *
@@ -199,6 +200,32 @@ public interface BehaviorAnnex extends AnnexSubclause, BehaviorElement
    */
   EList<BehaviorCondition> getConditions();
   
+  /**
+   * Returns the value of the '<em><b>Initial State</b></em>' reference.
+   * <!-- begin-user-doc -->
+   * <p>
+   * If the meaning of the '<em>Initial State</em>' reference isn't clear,
+   * there really should be more of a description here...
+   * </p>
+   * <!-- end-user-doc -->
+   * @return the value of the '<em>Initial State</em>' reference.
+   * @see #setInitialState(BehaviorState)
+   * @see org.osate.ba.aadlba.AadlBaPackage#getBehaviorAnnex_InitialState()
+   * @model required="true"
+   * @generated
+   */
+  BehaviorState getInitialState();
+
+  /**
+   * Sets the value of the '{@link org.osate.ba.aadlba.BehaviorAnnex#getInitialState <em>Initial State</em>}' reference.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @param value the new value of the '<em>Initial State</em>' reference.
+   * @see #getInitialState()
+   * @generated
+   */
+  void setInitialState(BehaviorState value);
+
   /**
    * @generated NOT
    */

--- a/org.osate.ba/src/org/osate/ba/aadlba/BehaviorState.java
+++ b/org.osate.ba/src/org/osate/ba/aadlba/BehaviorState.java
@@ -19,6 +19,7 @@
  */
 package org.osate.ba.aadlba;
 
+import org.eclipse.emf.common.util.EList;
 import org.osate.aadl2.Mode;
 
 /**
@@ -33,6 +34,8 @@ import org.osate.aadl2.Mode;
  *   <li>{@link org.osate.ba.aadlba.BehaviorState#isComplete <em>Complete</em>}</li>
  *   <li>{@link org.osate.ba.aadlba.BehaviorState#isFinal <em>Final</em>}</li>
  *   <li>{@link org.osate.ba.aadlba.BehaviorState#getBindedMode <em>Binded Mode</em>}</li>
+ *   <li>{@link org.osate.ba.aadlba.BehaviorState#getIncomingTransitions <em>Incoming Transitions</em>}</li>
+ *   <li>{@link org.osate.ba.aadlba.BehaviorState#getOutgoingTransitions <em>Outgoing Transitions</em>}</li>
  * </ul>
  * </p>
  *
@@ -148,5 +151,41 @@ public interface BehaviorState extends BehaviorNamedElement
    * @generated
    */
   void setBindedMode(Mode value);
+
+  /**
+   * Returns the value of the '<em><b>Incoming Transitions</b></em>' reference list.
+   * The list contents are of type {@link org.osate.ba.aadlba.BehaviorTransition}.
+   * It is bidirectional and its opposite is '{@link org.osate.ba.aadlba.BehaviorTransition#getDestinationState <em>Destination State</em>}'.
+   * <!-- begin-user-doc -->
+   * <p>
+   * If the meaning of the '<em>Incoming Transitions</em>' reference list isn't clear,
+   * there really should be more of a description here...
+   * </p>
+   * <!-- end-user-doc -->
+   * @return the value of the '<em>Incoming Transitions</em>' reference list.
+   * @see org.osate.ba.aadlba.AadlBaPackage#getBehaviorState_IncomingTransitions()
+   * @see org.osate.ba.aadlba.BehaviorTransition#getDestinationState
+   * @model opposite="destinationState"
+   * @generated
+   */
+  EList<BehaviorTransition> getIncomingTransitions();
+
+  /**
+   * Returns the value of the '<em><b>Outgoing Transitions</b></em>' reference list.
+   * The list contents are of type {@link org.osate.ba.aadlba.BehaviorTransition}.
+   * It is bidirectional and its opposite is '{@link org.osate.ba.aadlba.BehaviorTransition#getSourceState <em>Source State</em>}'.
+   * <!-- begin-user-doc -->
+   * <p>
+   * If the meaning of the '<em>Outgoing Transitions</em>' reference list isn't clear,
+   * there really should be more of a description here...
+   * </p>
+   * <!-- end-user-doc -->
+   * @return the value of the '<em>Outgoing Transitions</em>' reference list.
+   * @see org.osate.ba.aadlba.AadlBaPackage#getBehaviorState_OutgoingTransitions()
+   * @see org.osate.ba.aadlba.BehaviorTransition#getSourceState
+   * @model opposite="sourceState"
+   * @generated
+   */
+  EList<BehaviorTransition> getOutgoingTransitions();
 
 } // BehaviorState

--- a/org.osate.ba/src/org/osate/ba/aadlba/BehaviorTransition.java
+++ b/org.osate.ba/src/org/osate/ba/aadlba/BehaviorTransition.java
@@ -44,6 +44,7 @@ public interface BehaviorTransition extends BehaviorNamedElement
 {
   /**
    * Returns the value of the '<em><b>Source State</b></em>' reference.
+   * It is bidirectional and its opposite is '{@link org.osate.ba.aadlba.BehaviorState#getOutgoingTransitions <em>Outgoing Transitions</em>}'.
    * <!-- begin-user-doc -->
    * <p>
    * If the meaning of the '<em>Source State</em>' reference isn't clear,
@@ -53,7 +54,8 @@ public interface BehaviorTransition extends BehaviorNamedElement
    * @return the value of the '<em>Source State</em>' reference.
    * @see #setSourceState(BehaviorState)
    * @see org.osate.ba.aadlba.AadlBaPackage#getBehaviorTransition_SourceState()
-   * @model
+   * @see org.osate.ba.aadlba.BehaviorState#getOutgoingTransitions
+   * @model opposite="outgoingTransitions"
    * @generated
    */
   BehaviorState getSourceState();
@@ -96,6 +98,7 @@ public interface BehaviorTransition extends BehaviorNamedElement
 
   /**
    * Returns the value of the '<em><b>Destination State</b></em>' reference.
+   * It is bidirectional and its opposite is '{@link org.osate.ba.aadlba.BehaviorState#getIncomingTransitions <em>Incoming Transitions</em>}'.
    * <!-- begin-user-doc -->
    * <p>
    * If the meaning of the '<em>Destination State</em>' reference isn't clear,
@@ -105,7 +108,8 @@ public interface BehaviorTransition extends BehaviorNamedElement
    * @return the value of the '<em>Destination State</em>' reference.
    * @see #setDestinationState(BehaviorState)
    * @see org.osate.ba.aadlba.AadlBaPackage#getBehaviorTransition_DestinationState()
-   * @model
+   * @see org.osate.ba.aadlba.BehaviorState#getIncomingTransitions
+   * @model opposite="incomingTransitions"
    * @generated
    */
   BehaviorState getDestinationState();

--- a/org.osate.ba/src/org/osate/ba/aadlba/impl/AadlBaPackageImpl.java
+++ b/org.osate.ba/src/org/osate/ba/aadlba/impl/AadlBaPackageImpl.java
@@ -1509,6 +1509,26 @@ public class AadlBaPackageImpl extends EPackageImpl implements AadlBaPackage
    * <!-- end-user-doc -->
    * @generated
    */
+  public EReference getBehaviorState_IncomingTransitions()
+  {
+    return (EReference)behaviorStateEClass.getEStructuralFeatures().get(4);
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public EReference getBehaviorState_OutgoingTransitions()
+  {
+    return (EReference)behaviorStateEClass.getEStructuralFeatures().get(5);
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
   public EClass getBehaviorStringLiteral()
   {
     return behaviorStringLiteralEClass;
@@ -3329,6 +3349,8 @@ public class AadlBaPackageImpl extends EPackageImpl implements AadlBaPackage
     createEAttribute(behaviorStateEClass, BEHAVIOR_STATE__COMPLETE);
     createEAttribute(behaviorStateEClass, BEHAVIOR_STATE__FINAL);
     createEReference(behaviorStateEClass, BEHAVIOR_STATE__BINDED_MODE);
+    createEReference(behaviorStateEClass, BEHAVIOR_STATE__INCOMING_TRANSITIONS);
+    createEReference(behaviorStateEClass, BEHAVIOR_STATE__OUTGOING_TRANSITIONS);
 
     behaviorStringLiteralEClass = createEClass(BEHAVIOR_STRING_LITERAL);
 
@@ -3352,15 +3374,15 @@ public class AadlBaPackageImpl extends EPackageImpl implements AadlBaPackage
 
     classifierFeatureHolderEClass = createEClass(CLASSIFIER_FEATURE_HOLDER);
 
+    classifierFeaturePropertyReferenceEClass = createEClass(CLASSIFIER_FEATURE_PROPERTY_REFERENCE);
+    createEReference(classifierFeaturePropertyReferenceEClass, CLASSIFIER_FEATURE_PROPERTY_REFERENCE__COMPONENT);
+
     classifierPropertyReferenceEClass = createEClass(CLASSIFIER_PROPERTY_REFERENCE);
     createEReference(classifierPropertyReferenceEClass, CLASSIFIER_PROPERTY_REFERENCE__CLASSIFIER);
 
     communicationActionEClass = createEClass(COMMUNICATION_ACTION);
 
     completionRelativeTimeoutEClass = createEClass(COMPLETION_RELATIVE_TIMEOUT);
-
-    classifierFeaturePropertyReferenceEClass = createEClass(CLASSIFIER_FEATURE_PROPERTY_REFERENCE);
-    createEReference(classifierFeaturePropertyReferenceEClass, CLASSIFIER_FEATURE_PROPERTY_REFERENCE__COMPONENT);
 
     condStatementEClass = createEClass(COND_STATEMENT);
     createEReference(condStatementEClass, COND_STATEMENT__BEHAVIOR_ACTIONS);
@@ -3496,26 +3518,26 @@ public class AadlBaPackageImpl extends EPackageImpl implements AadlBaPackage
     createEReference(portSendActionEClass, PORT_SEND_ACTION__PORT);
     createEReference(portSendActionEClass, PORT_SEND_ACTION__VALUE_EXPRESSION);
 
+    propertyAssociationHolderEClass = createEClass(PROPERTY_ASSOCIATION_HOLDER);
+
+    propertyElementHolderEClass = createEClass(PROPERTY_ELEMENT_HOLDER);
+    createEReference(propertyElementHolderEClass, PROPERTY_ELEMENT_HOLDER__ELEMENT);
+
+    propertyExpressionHolderEClass = createEClass(PROPERTY_EXPRESSION_HOLDER);
+
     propertyNameFieldEClass = createEClass(PROPERTY_NAME_FIELD);
 
     propertyNameHolderEClass = createEClass(PROPERTY_NAME_HOLDER);
     createEReference(propertyNameHolderEClass, PROPERTY_NAME_HOLDER__PROPERTY);
     createEReference(propertyNameHolderEClass, PROPERTY_NAME_HOLDER__FIELD);
 
-    propertyElementHolderEClass = createEClass(PROPERTY_ELEMENT_HOLDER);
-    createEReference(propertyElementHolderEClass, PROPERTY_ELEMENT_HOLDER__ELEMENT);
-
-    propertyAssociationHolderEClass = createEClass(PROPERTY_ASSOCIATION_HOLDER);
-
-    propertyExpressionHolderEClass = createEClass(PROPERTY_EXPRESSION_HOLDER);
-
-    propertyTypeHolderEClass = createEClass(PROPERTY_TYPE_HOLDER);
-
     propertyReferenceEClass = createEClass(PROPERTY_REFERENCE);
     createEReference(propertyReferenceEClass, PROPERTY_REFERENCE__PROPERTIES);
 
     propertySetPropertyReferenceEClass = createEClass(PROPERTY_SET_PROPERTY_REFERENCE);
     createEReference(propertySetPropertyReferenceEClass, PROPERTY_SET_PROPERTY_REFERENCE__PROPERTY_SET);
+
+    propertyTypeHolderEClass = createEClass(PROPERTY_TYPE_HOLDER);
 
     prototypeHolderEClass = createEClass(PROTOTYPE_HOLDER);
     createEReference(prototypeHolderEClass, PROTOTYPE_HOLDER__PROTOTYPE_BINDING);
@@ -3679,11 +3701,11 @@ public class AadlBaPackageImpl extends EPackageImpl implements AadlBaPackage
     calledSubprogramHolderEClass.getESuperTypes().add(this.getIndexableElement());
     calledSubprogramHolderEClass.getESuperTypes().add(this.getGroupableElement());
     classifierFeatureHolderEClass.getESuperTypes().add(this.getElementHolder());
+    classifierFeaturePropertyReferenceEClass.getESuperTypes().add(this.getPropertyReference());
     classifierPropertyReferenceEClass.getESuperTypes().add(this.getPropertyReference());
     communicationActionEClass.getESuperTypes().add(this.getBasicAction());
     completionRelativeTimeoutEClass.getESuperTypes().add(this.getBehaviorTime());
     completionRelativeTimeoutEClass.getESuperTypes().add(this.getDispatchRelativeTimeout());
-    classifierFeaturePropertyReferenceEClass.getESuperTypes().add(this.getPropertyReference());
     condStatementEClass.getESuperTypes().add(this.getBehaviorAction());
     dataAccessHolderEClass.getESuperTypes().add(this.getDataHolder());
     dataAccessHolderEClass.getESuperTypes().add(this.getTarget());
@@ -3778,16 +3800,16 @@ public class AadlBaPackageImpl extends EPackageImpl implements AadlBaPackage
     portPrototypeHolderEClass.getESuperTypes().add(this.getPrototypeHolder());
     portPrototypeHolderEClass.getESuperTypes().add(this.getTarget());
     portSendActionEClass.getESuperTypes().add(this.getCommunicationAction());
-    propertyNameFieldEClass.getESuperTypes().add(this.getBehaviorElement());
-    propertyNameHolderEClass.getESuperTypes().add(this.getBehaviorElement());
+    propertyAssociationHolderEClass.getESuperTypes().add(this.getPropertyElementHolder());
     propertyElementHolderEClass.getESuperTypes().add(this.getBehaviorElement());
     propertyElementHolderEClass.getESuperTypes().add(this.getIndexableElement());
-    propertyAssociationHolderEClass.getESuperTypes().add(this.getPropertyElementHolder());
     propertyExpressionHolderEClass.getESuperTypes().add(this.getPropertyElementHolder());
-    propertyTypeHolderEClass.getESuperTypes().add(this.getPropertyElementHolder());
+    propertyNameFieldEClass.getESuperTypes().add(this.getBehaviorElement());
+    propertyNameHolderEClass.getESuperTypes().add(this.getBehaviorElement());
     propertyReferenceEClass.getESuperTypes().add(this.getValueConstant());
     propertyReferenceEClass.getESuperTypes().add(this.getIntegerValueConstant());
     propertySetPropertyReferenceEClass.getESuperTypes().add(this.getPropertyReference());
+    propertyTypeHolderEClass.getESuperTypes().add(this.getPropertyElementHolder());
     prototypeHolderEClass.getESuperTypes().add(this.getIndexableElement());
     prototypeHolderEClass.getESuperTypes().add(this.getGroupableElement());
     prototypeHolderEClass.getESuperTypes().add(this.getClassifierFeatureHolder());
@@ -3892,6 +3914,8 @@ public class AadlBaPackageImpl extends EPackageImpl implements AadlBaPackage
     initEAttribute(getBehaviorState_Complete(), this.getBoolean(), "complete", "false", 1, 1, BehaviorState.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
     initEAttribute(getBehaviorState_Final(), this.getBoolean(), "final", "false", 1, 1, BehaviorState.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
     initEReference(getBehaviorState_BindedMode(), theAadl2Package.getMode(), null, "bindedMode", null, 0, 1, BehaviorState.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+    initEReference(getBehaviorState_IncomingTransitions(), this.getBehaviorTransition(), this.getBehaviorTransition_DestinationState(), "incomingTransitions", null, 0, -1, BehaviorState.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+    initEReference(getBehaviorState_OutgoingTransitions(), this.getBehaviorTransition(), this.getBehaviorTransition_SourceState(), "outgoingTransitions", null, 0, -1, BehaviorState.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
     initEClass(behaviorStringLiteralEClass, BehaviorStringLiteral.class, "BehaviorStringLiteral", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
@@ -3900,9 +3924,9 @@ public class AadlBaPackageImpl extends EPackageImpl implements AadlBaPackage
     initEReference(getBehaviorTime_Unit(), theAadl2Package.getUnitLiteral(), null, "unit", null, 0, 1, BehaviorTime.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
     initEClass(behaviorTransitionEClass, BehaviorTransition.class, "BehaviorTransition", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-    initEReference(getBehaviorTransition_SourceState(), this.getBehaviorState(), null, "sourceState", null, 0, 1, BehaviorTransition.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+    initEReference(getBehaviorTransition_SourceState(), this.getBehaviorState(), this.getBehaviorState_OutgoingTransitions(), "sourceState", null, 0, 1, BehaviorTransition.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
     initEReference(getBehaviorTransition_Condition(), this.getBehaviorCondition(), null, "condition", null, 0, 1, BehaviorTransition.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-    initEReference(getBehaviorTransition_DestinationState(), this.getBehaviorState(), null, "destinationState", null, 0, 1, BehaviorTransition.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+    initEReference(getBehaviorTransition_DestinationState(), this.getBehaviorState(), this.getBehaviorState_IncomingTransitions(), "destinationState", null, 0, 1, BehaviorTransition.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
     initEReference(getBehaviorTransition_ActionBlock(), this.getBehaviorActionBlock(), null, "actionBlock", null, 0, 1, BehaviorTransition.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
     initEAttribute(getBehaviorTransition_Priority(), theAadl2Package.getInteger(), "priority", "-1", 0, 1, BehaviorTransition.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
@@ -3925,15 +3949,15 @@ public class AadlBaPackageImpl extends EPackageImpl implements AadlBaPackage
 
     addEOperation(classifierFeatureHolderEClass, theAadl2Package.getClassifierFeature(), "getClassifierFeature", 1, 1, IS_UNIQUE, IS_ORDERED);
 
+    initEClass(classifierFeaturePropertyReferenceEClass, ClassifierFeaturePropertyReference.class, "ClassifierFeaturePropertyReference", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+    initEReference(getClassifierFeaturePropertyReference_Component(), this.getClassifierFeatureHolder(), null, "component", null, 1, 1, ClassifierFeaturePropertyReference.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
     initEClass(classifierPropertyReferenceEClass, ClassifierPropertyReference.class, "ClassifierPropertyReference", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
     initEReference(getClassifierPropertyReference_Classifier(), theAadl2Package.getClassifier(), null, "classifier", null, 1, 1, ClassifierPropertyReference.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
     initEClass(communicationActionEClass, CommunicationAction.class, "CommunicationAction", IS_ABSTRACT, IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
     initEClass(completionRelativeTimeoutEClass, CompletionRelativeTimeout.class, "CompletionRelativeTimeout", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-
-    initEClass(classifierFeaturePropertyReferenceEClass, ClassifierFeaturePropertyReference.class, "ClassifierFeaturePropertyReference", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-    initEReference(getClassifierFeaturePropertyReference_Component(), this.getClassifierFeatureHolder(), null, "component", null, 1, 1, ClassifierFeaturePropertyReference.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
     initEClass(condStatementEClass, CondStatement.class, "CondStatement", IS_ABSTRACT, IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
     initEReference(getCondStatement_BehaviorActions(), this.getBehaviorActions(), null, "behaviorActions", null, 1, 1, CondStatement.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
@@ -4124,21 +4148,15 @@ public class AadlBaPackageImpl extends EPackageImpl implements AadlBaPackage
     initEReference(getPortSendAction_Port(), this.getActualPortHolder(), null, "port", null, 0, 1, PortSendAction.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
     initEReference(getPortSendAction_ValueExpression(), this.getValueExpression(), null, "valueExpression", null, 0, 1, PortSendAction.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-    initEClass(propertyNameFieldEClass, PropertyNameField.class, "PropertyNameField", IS_ABSTRACT, IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-
-    initEClass(propertyNameHolderEClass, PropertyNameHolder.class, "PropertyNameHolder", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-    initEReference(getPropertyNameHolder_Property(), this.getPropertyElementHolder(), null, "property", null, 1, 1, PropertyNameHolder.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-    initEReference(getPropertyNameHolder_Field(), this.getPropertyNameField(), null, "field", null, 0, 1, PropertyNameHolder.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-
-    initEClass(propertyElementHolderEClass, PropertyElementHolder.class, "PropertyElementHolder", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-    initEReference(getPropertyElementHolder_Element(), theAadl2Package.getElement(), null, "element", null, 1, 1, PropertyElementHolder.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-
     initEClass(propertyAssociationHolderEClass, PropertyAssociationHolder.class, "PropertyAssociationHolder", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
     op = addEOperation(propertyAssociationHolderEClass, null, "setPropertyAssociation", 1, 1, IS_UNIQUE, IS_ORDERED);
     addEParameter(op, theAadl2Package.getPropertyAssociation(), "propertyAssociation", 1, 1, IS_UNIQUE, IS_ORDERED);
 
     addEOperation(propertyAssociationHolderEClass, theAadl2Package.getPropertyAssociation(), "getPropertyAssociation", 1, 1, IS_UNIQUE, IS_ORDERED);
+
+    initEClass(propertyElementHolderEClass, PropertyElementHolder.class, "PropertyElementHolder", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+    initEReference(getPropertyElementHolder_Element(), theAadl2Package.getElement(), null, "element", null, 1, 1, PropertyElementHolder.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
     initEClass(propertyExpressionHolderEClass, PropertyExpressionHolder.class, "PropertyExpressionHolder", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
@@ -4147,18 +4165,24 @@ public class AadlBaPackageImpl extends EPackageImpl implements AadlBaPackage
 
     addEOperation(propertyExpressionHolderEClass, theAadl2Package.getPropertyExpression(), "getPropertyExpression", 1, 1, IS_UNIQUE, IS_ORDERED);
 
-    initEClass(propertyTypeHolderEClass, PropertyTypeHolder.class, "PropertyTypeHolder", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+    initEClass(propertyNameFieldEClass, PropertyNameField.class, "PropertyNameField", IS_ABSTRACT, IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
-    op = addEOperation(propertyTypeHolderEClass, null, "setPropertyType", 1, 1, IS_UNIQUE, IS_ORDERED);
-    addEParameter(op, theAadl2Package.getPropertyType(), "propertyType", 1, 1, IS_UNIQUE, IS_ORDERED);
-
-    addEOperation(propertyTypeHolderEClass, theAadl2Package.getPropertyType(), "getPropertyType", 1, 1, IS_UNIQUE, IS_ORDERED);
+    initEClass(propertyNameHolderEClass, PropertyNameHolder.class, "PropertyNameHolder", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+    initEReference(getPropertyNameHolder_Property(), this.getPropertyElementHolder(), null, "property", null, 1, 1, PropertyNameHolder.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+    initEReference(getPropertyNameHolder_Field(), this.getPropertyNameField(), null, "field", null, 0, 1, PropertyNameHolder.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
     initEClass(propertyReferenceEClass, PropertyReference.class, "PropertyReference", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
     initEReference(getPropertyReference_Properties(), this.getPropertyNameHolder(), null, "properties", null, 1, -1, PropertyReference.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
     initEClass(propertySetPropertyReferenceEClass, PropertySetPropertyReference.class, "PropertySetPropertyReference", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
     initEReference(getPropertySetPropertyReference_PropertySet(), theAadl2Package.getPropertySet(), null, "propertySet", null, 0, 1, PropertySetPropertyReference.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+
+    initEClass(propertyTypeHolderEClass, PropertyTypeHolder.class, "PropertyTypeHolder", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+
+    op = addEOperation(propertyTypeHolderEClass, null, "setPropertyType", 1, 1, IS_UNIQUE, IS_ORDERED);
+    addEParameter(op, theAadl2Package.getPropertyType(), "propertyType", 1, 1, IS_UNIQUE, IS_ORDERED);
+
+    addEOperation(propertyTypeHolderEClass, theAadl2Package.getPropertyType(), "getPropertyType", 1, 1, IS_UNIQUE, IS_ORDERED);
 
     initEClass(prototypeHolderEClass, PrototypeHolder.class, "PrototypeHolder", IS_ABSTRACT, IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
     initEReference(getPrototypeHolder_PrototypeBinding(), theAadl2Package.getPrototypeBinding(), null, "prototypeBinding", null, 0, 1, PrototypeHolder.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);

--- a/org.osate.ba/src/org/osate/ba/aadlba/impl/AadlBaPackageImpl.java
+++ b/org.osate.ba/src/org/osate/ba/aadlba/impl/AadlBaPackageImpl.java
@@ -1369,6 +1369,16 @@ public class AadlBaPackageImpl extends EPackageImpl implements AadlBaPackage
    * <!-- end-user-doc -->
    * @generated
    */
+  public EReference getBehaviorAnnex_InitialState()
+  {
+    return (EReference)behaviorAnnexEClass.getEStructuralFeatures().get(5);
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
   public EClass getBehaviorBooleanLiteral()
   {
     return behaviorBooleanLiteralEClass;
@@ -3327,6 +3337,7 @@ public class AadlBaPackageImpl extends EPackageImpl implements AadlBaPackage
     createEReference(behaviorAnnexEClass, BEHAVIOR_ANNEX__TRANSITIONS);
     createEReference(behaviorAnnexEClass, BEHAVIOR_ANNEX__ACTIONS);
     createEReference(behaviorAnnexEClass, BEHAVIOR_ANNEX__CONDITIONS);
+    createEReference(behaviorAnnexEClass, BEHAVIOR_ANNEX__INITIAL_STATE);
 
     behaviorBooleanLiteralEClass = createEClass(BEHAVIOR_BOOLEAN_LITERAL);
 
@@ -3892,6 +3903,7 @@ public class AadlBaPackageImpl extends EPackageImpl implements AadlBaPackage
     initEReference(getBehaviorAnnex_Transitions(), this.getBehaviorTransition(), null, "transitions", null, 0, -1, BehaviorAnnex.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
     initEReference(getBehaviorAnnex_Actions(), this.getBehaviorActionBlock(), null, "actions", null, 0, -1, BehaviorAnnex.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
     initEReference(getBehaviorAnnex_Conditions(), this.getBehaviorCondition(), null, "conditions", null, 0, -1, BehaviorAnnex.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+    initEReference(getBehaviorAnnex_InitialState(), this.getBehaviorState(), null, "initialState", null, 1, 1, BehaviorAnnex.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
     initEClass(behaviorBooleanLiteralEClass, BehaviorBooleanLiteral.class, "BehaviorBooleanLiteral", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 

--- a/org.osate.ba/src/org/osate/ba/aadlba/impl/BehaviorAnnexImpl.java
+++ b/org.osate.ba/src/org/osate/ba/aadlba/impl/BehaviorAnnexImpl.java
@@ -23,10 +23,13 @@ import java.util.Collection ;
 import java.util.HashMap ;
 import java.util.Map ;
 
+import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain ;
 import org.eclipse.emf.common.util.EList ;
 import org.eclipse.emf.ecore.EClass ;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.InternalEObject ;
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.util.EObjectContainmentEList ;
 import org.eclipse.emf.ecore.util.InternalEList ;
 import org.osate.aadl2.Element ;
@@ -54,6 +57,7 @@ import org.osate.ba.utils.AadlBaLocationReference ;
  *   <li>{@link org.osate.ba.aadlba.impl.BehaviorAnnexImpl#getTransitions <em>Transitions</em>}</li>
  *   <li>{@link org.osate.ba.aadlba.impl.BehaviorAnnexImpl#getActions <em>Actions</em>}</li>
  *   <li>{@link org.osate.ba.aadlba.impl.BehaviorAnnexImpl#getConditions <em>Conditions</em>}</li>
+ *   <li>{@link org.osate.ba.aadlba.impl.BehaviorAnnexImpl#getInitialState <em>Initial State</em>}</li>
  * </ul>
  * </p>
  *
@@ -110,6 +114,16 @@ public class BehaviorAnnexImpl extends AnnexSubclauseImpl implements BehaviorAnn
    * @ordered
    */
   protected EList<BehaviorCondition> conditions;
+
+  /**
+   * The cached value of the '{@link #getInitialState() <em>Initial State</em>}' reference.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see #getInitialState()
+   * @generated
+   * @ordered
+   */
+  protected BehaviorState initialState;
 
   /**
    * <!-- begin-user-doc -->
@@ -267,6 +281,49 @@ public class BehaviorAnnexImpl extends AnnexSubclauseImpl implements BehaviorAnn
    * <!-- end-user-doc -->
    * @generated
    */
+  public BehaviorState getInitialState()
+  {
+    if (initialState != null && ((EObject)initialState).eIsProxy())
+    {
+      InternalEObject oldInitialState = (InternalEObject)initialState;
+      initialState = (BehaviorState)eResolveProxy(oldInitialState);
+      if (initialState != oldInitialState)
+      {
+        if (eNotificationRequired())
+          eNotify(new ENotificationImpl(this, Notification.RESOLVE, AadlBaPackage.BEHAVIOR_ANNEX__INITIAL_STATE, oldInitialState, initialState));
+      }
+    }
+    return initialState;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public BehaviorState basicGetInitialState()
+  {
+    return initialState;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public void setInitialState(BehaviorState newInitialState)
+  {
+    BehaviorState oldInitialState = initialState;
+    initialState = newInitialState;
+    if (eNotificationRequired())
+      eNotify(new ENotificationImpl(this, Notification.SET, AadlBaPackage.BEHAVIOR_ANNEX__INITIAL_STATE, oldInitialState, initialState));
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
   @Override
   public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs)
   {
@@ -306,6 +363,9 @@ public class BehaviorAnnexImpl extends AnnexSubclauseImpl implements BehaviorAnn
         return getActions();
       case AadlBaPackage.BEHAVIOR_ANNEX__CONDITIONS:
         return getConditions();
+      case AadlBaPackage.BEHAVIOR_ANNEX__INITIAL_STATE:
+        if (resolve) return getInitialState();
+        return basicGetInitialState();
     }
     return super.eGet(featureID, resolve, coreType);
   }
@@ -341,6 +401,9 @@ public class BehaviorAnnexImpl extends AnnexSubclauseImpl implements BehaviorAnn
         getConditions().clear();
         getConditions().addAll((Collection<? extends BehaviorCondition>)newValue);
         return;
+      case AadlBaPackage.BEHAVIOR_ANNEX__INITIAL_STATE:
+        setInitialState((BehaviorState)newValue);
+        return;
     }
     super.eSet(featureID, newValue);
   }
@@ -370,6 +433,9 @@ public class BehaviorAnnexImpl extends AnnexSubclauseImpl implements BehaviorAnn
       case AadlBaPackage.BEHAVIOR_ANNEX__CONDITIONS:
         getConditions().clear();
         return;
+      case AadlBaPackage.BEHAVIOR_ANNEX__INITIAL_STATE:
+        setInitialState((BehaviorState)null);
+        return;
     }
     super.eUnset(featureID);
   }
@@ -394,6 +460,8 @@ public class BehaviorAnnexImpl extends AnnexSubclauseImpl implements BehaviorAnn
         return actions != null && !actions.isEmpty();
       case AadlBaPackage.BEHAVIOR_ANNEX__CONDITIONS:
         return conditions != null && !conditions.isEmpty();
+      case AadlBaPackage.BEHAVIOR_ANNEX__INITIAL_STATE:
+        return initialState != null;
     }
     return super.eIsSet(featureID);
   }

--- a/org.osate.ba/src/org/osate/ba/aadlba/impl/BehaviorStateImpl.java
+++ b/org.osate.ba/src/org/osate/ba/aadlba/impl/BehaviorStateImpl.java
@@ -20,17 +20,21 @@
 package org.osate.ba.aadlba.impl;
 
 
-import org.eclipse.emf.common.notify.Notification;
+import java.util.Collection ;
 
-import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.InternalEObject;
-
-import org.eclipse.emf.ecore.impl.ENotificationImpl;
-
-import org.osate.aadl2.Mode;
+import org.eclipse.emf.common.notify.Notification ;
+import org.eclipse.emf.common.notify.NotificationChain ;
+import org.eclipse.emf.common.util.EList ;
+import org.eclipse.emf.ecore.EClass ;
+import org.eclipse.emf.ecore.EObject ;
+import org.eclipse.emf.ecore.InternalEObject ;
+import org.eclipse.emf.ecore.impl.ENotificationImpl ;
+import org.eclipse.emf.ecore.util.EObjectWithInverseResolvingEList ;
+import org.eclipse.emf.ecore.util.InternalEList ;
+import org.osate.aadl2.Mode ;
 import org.osate.ba.aadlba.AadlBaPackage ;
 import org.osate.ba.aadlba.BehaviorState ;
+import org.osate.ba.aadlba.BehaviorTransition;
 import org.osate.ba.utils.AadlBaLocationReference ;
 
 /**
@@ -44,6 +48,8 @@ import org.osate.ba.utils.AadlBaLocationReference ;
  *   <li>{@link org.osate.ba.aadlba.impl.BehaviorStateImpl#isComplete <em>Complete</em>}</li>
  *   <li>{@link org.osate.ba.aadlba.impl.BehaviorStateImpl#isFinal <em>Final</em>}</li>
  *   <li>{@link org.osate.ba.aadlba.impl.BehaviorStateImpl#getBindedMode <em>Binded Mode</em>}</li>
+ *   <li>{@link org.osate.ba.aadlba.impl.BehaviorStateImpl#getIncomingTransitions <em>Incoming Transitions</em>}</li>
+ *   <li>{@link org.osate.ba.aadlba.impl.BehaviorStateImpl#getOutgoingTransitions <em>Outgoing Transitions</em>}</li>
  * </ul>
  * </p>
  *
@@ -120,6 +126,26 @@ public class BehaviorStateImpl extends BehaviorNamedElementImpl implements Behav
    * @ordered
    */
   protected Mode bindedMode;
+
+  /**
+   * The cached value of the '{@link #getIncomingTransitions() <em>Incoming Transitions</em>}' reference list.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see #getIncomingTransitions()
+   * @generated
+   * @ordered
+   */
+  protected EList<BehaviorTransition> incomingTransitions;
+
+  /**
+   * The cached value of the '{@link #getOutgoingTransitions() <em>Outgoing Transitions</em>}' reference list.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see #getOutgoingTransitions()
+   * @generated
+   * @ordered
+   */
+  protected EList<BehaviorTransition> outgoingTransitions;
 
   /**
    * <!-- begin-user-doc -->
@@ -259,6 +285,71 @@ public class BehaviorStateImpl extends BehaviorNamedElementImpl implements Behav
    * <!-- end-user-doc -->
    * @generated
    */
+  public EList<BehaviorTransition> getIncomingTransitions()
+  {
+    if (incomingTransitions == null)
+    {
+      incomingTransitions = new EObjectWithInverseResolvingEList<BehaviorTransition>(BehaviorTransition.class, this, AadlBaPackage.BEHAVIOR_STATE__INCOMING_TRANSITIONS, AadlBaPackage.BEHAVIOR_TRANSITION__DESTINATION_STATE);
+    }
+    return incomingTransitions;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public EList<BehaviorTransition> getOutgoingTransitions()
+  {
+    if (outgoingTransitions == null)
+    {
+      outgoingTransitions = new EObjectWithInverseResolvingEList<BehaviorTransition>(BehaviorTransition.class, this, AadlBaPackage.BEHAVIOR_STATE__OUTGOING_TRANSITIONS, AadlBaPackage.BEHAVIOR_TRANSITION__SOURCE_STATE);
+    }
+    return outgoingTransitions;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  @SuppressWarnings("unchecked")
+  @Override
+  public NotificationChain eInverseAdd(InternalEObject otherEnd, int featureID, NotificationChain msgs)
+  {
+    switch (featureID)
+    {
+      case AadlBaPackage.BEHAVIOR_STATE__INCOMING_TRANSITIONS:
+        return ((InternalEList<InternalEObject>)(InternalEList<?>)getIncomingTransitions()).basicAdd(otherEnd, msgs);
+      case AadlBaPackage.BEHAVIOR_STATE__OUTGOING_TRANSITIONS:
+        return ((InternalEList<InternalEObject>)(InternalEList<?>)getOutgoingTransitions()).basicAdd(otherEnd, msgs);
+    }
+    return super.eInverseAdd(otherEnd, featureID, msgs);
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  @Override
+  public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs)
+  {
+    switch (featureID)
+    {
+      case AadlBaPackage.BEHAVIOR_STATE__INCOMING_TRANSITIONS:
+        return ((InternalEList<?>)getIncomingTransitions()).basicRemove(otherEnd, msgs);
+      case AadlBaPackage.BEHAVIOR_STATE__OUTGOING_TRANSITIONS:
+        return ((InternalEList<?>)getOutgoingTransitions()).basicRemove(otherEnd, msgs);
+    }
+    return super.eInverseRemove(otherEnd, featureID, msgs);
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
   @Override
   public Object eGet(int featureID, boolean resolve, boolean coreType)
   {
@@ -273,6 +364,10 @@ public class BehaviorStateImpl extends BehaviorNamedElementImpl implements Behav
       case AadlBaPackage.BEHAVIOR_STATE__BINDED_MODE:
         if (resolve) return getBindedMode();
         return basicGetBindedMode();
+      case AadlBaPackage.BEHAVIOR_STATE__INCOMING_TRANSITIONS:
+        return getIncomingTransitions();
+      case AadlBaPackage.BEHAVIOR_STATE__OUTGOING_TRANSITIONS:
+        return getOutgoingTransitions();
     }
     return super.eGet(featureID, resolve, coreType);
   }
@@ -282,6 +377,7 @@ public class BehaviorStateImpl extends BehaviorNamedElementImpl implements Behav
    * <!-- end-user-doc -->
    * @generated
    */
+  @SuppressWarnings("unchecked")
   @Override
   public void eSet(int featureID, Object newValue)
   {
@@ -298,6 +394,14 @@ public class BehaviorStateImpl extends BehaviorNamedElementImpl implements Behav
         return;
       case AadlBaPackage.BEHAVIOR_STATE__BINDED_MODE:
         setBindedMode((Mode)newValue);
+        return;
+      case AadlBaPackage.BEHAVIOR_STATE__INCOMING_TRANSITIONS:
+        getIncomingTransitions().clear();
+        getIncomingTransitions().addAll((Collection<? extends BehaviorTransition>)newValue);
+        return;
+      case AadlBaPackage.BEHAVIOR_STATE__OUTGOING_TRANSITIONS:
+        getOutgoingTransitions().clear();
+        getOutgoingTransitions().addAll((Collection<? extends BehaviorTransition>)newValue);
         return;
     }
     super.eSet(featureID, newValue);
@@ -325,6 +429,12 @@ public class BehaviorStateImpl extends BehaviorNamedElementImpl implements Behav
       case AadlBaPackage.BEHAVIOR_STATE__BINDED_MODE:
         setBindedMode((Mode)null);
         return;
+      case AadlBaPackage.BEHAVIOR_STATE__INCOMING_TRANSITIONS:
+        getIncomingTransitions().clear();
+        return;
+      case AadlBaPackage.BEHAVIOR_STATE__OUTGOING_TRANSITIONS:
+        getOutgoingTransitions().clear();
+        return;
     }
     super.eUnset(featureID);
   }
@@ -347,6 +457,10 @@ public class BehaviorStateImpl extends BehaviorNamedElementImpl implements Behav
         return final_ != FINAL_EDEFAULT;
       case AadlBaPackage.BEHAVIOR_STATE__BINDED_MODE:
         return bindedMode != null;
+      case AadlBaPackage.BEHAVIOR_STATE__INCOMING_TRANSITIONS:
+        return incomingTransitions != null && !incomingTransitions.isEmpty();
+      case AadlBaPackage.BEHAVIOR_STATE__OUTGOING_TRANSITIONS:
+        return outgoingTransitions != null && !outgoingTransitions.isEmpty();
     }
     return super.eIsSet(featureID);
   }

--- a/org.osate.ba/src/org/osate/ba/aadlba/impl/BehaviorTransitionImpl.java
+++ b/org.osate.ba/src/org/osate/ba/aadlba/impl/BehaviorTransitionImpl.java
@@ -170,12 +170,37 @@ public class BehaviorTransitionImpl extends BehaviorNamedElementImpl implements 
    * <!-- end-user-doc -->
    * @generated
    */
-  public void setSourceState(BehaviorState newSourceState)
+  public NotificationChain basicSetSourceState(BehaviorState newSourceState, NotificationChain msgs)
   {
     BehaviorState oldSourceState = sourceState;
     sourceState = newSourceState;
     if (eNotificationRequired())
-      eNotify(new ENotificationImpl(this, Notification.SET, AadlBaPackage.BEHAVIOR_TRANSITION__SOURCE_STATE, oldSourceState, sourceState));
+    {
+      ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, AadlBaPackage.BEHAVIOR_TRANSITION__SOURCE_STATE, oldSourceState, newSourceState);
+      if (msgs == null) msgs = notification; else msgs.add(notification);
+    }
+    return msgs;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public void setSourceState(BehaviorState newSourceState)
+  {
+    if (newSourceState != sourceState)
+    {
+      NotificationChain msgs = null;
+      if (sourceState != null)
+        msgs = ((InternalEObject)sourceState).eInverseRemove(this, AadlBaPackage.BEHAVIOR_STATE__OUTGOING_TRANSITIONS, BehaviorState.class, msgs);
+      if (newSourceState != null)
+        msgs = ((InternalEObject)newSourceState).eInverseAdd(this, AadlBaPackage.BEHAVIOR_STATE__OUTGOING_TRANSITIONS, BehaviorState.class, msgs);
+      msgs = basicSetSourceState(newSourceState, msgs);
+      if (msgs != null) msgs.dispatch();
+    }
+    else if (eNotificationRequired())
+      eNotify(new ENotificationImpl(this, Notification.SET, AadlBaPackage.BEHAVIOR_TRANSITION__SOURCE_STATE, newSourceState, newSourceState));
   }
 
   /**
@@ -261,12 +286,37 @@ public class BehaviorTransitionImpl extends BehaviorNamedElementImpl implements 
    * <!-- end-user-doc -->
    * @generated
    */
-  public void setDestinationState(BehaviorState newDestinationState)
+  public NotificationChain basicSetDestinationState(BehaviorState newDestinationState, NotificationChain msgs)
   {
     BehaviorState oldDestinationState = destinationState;
     destinationState = newDestinationState;
     if (eNotificationRequired())
-      eNotify(new ENotificationImpl(this, Notification.SET, AadlBaPackage.BEHAVIOR_TRANSITION__DESTINATION_STATE, oldDestinationState, destinationState));
+    {
+      ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, AadlBaPackage.BEHAVIOR_TRANSITION__DESTINATION_STATE, oldDestinationState, newDestinationState);
+      if (msgs == null) msgs = notification; else msgs.add(notification);
+    }
+    return msgs;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  public void setDestinationState(BehaviorState newDestinationState)
+  {
+    if (newDestinationState != destinationState)
+    {
+      NotificationChain msgs = null;
+      if (destinationState != null)
+        msgs = ((InternalEObject)destinationState).eInverseRemove(this, AadlBaPackage.BEHAVIOR_STATE__INCOMING_TRANSITIONS, BehaviorState.class, msgs);
+      if (newDestinationState != null)
+        msgs = ((InternalEObject)newDestinationState).eInverseAdd(this, AadlBaPackage.BEHAVIOR_STATE__INCOMING_TRANSITIONS, BehaviorState.class, msgs);
+      msgs = basicSetDestinationState(newDestinationState, msgs);
+      if (msgs != null) msgs.dispatch();
+    }
+    else if (eNotificationRequired())
+      eNotify(new ENotificationImpl(this, Notification.SET, AadlBaPackage.BEHAVIOR_TRANSITION__DESTINATION_STATE, newDestinationState, newDestinationState));
   }
 
   /**
@@ -341,12 +391,38 @@ public class BehaviorTransitionImpl extends BehaviorNamedElementImpl implements 
    * @generated
    */
   @Override
+  public NotificationChain eInverseAdd(InternalEObject otherEnd, int featureID, NotificationChain msgs)
+  {
+    switch (featureID)
+    {
+      case AadlBaPackage.BEHAVIOR_TRANSITION__SOURCE_STATE:
+        if (sourceState != null)
+          msgs = ((InternalEObject)sourceState).eInverseRemove(this, AadlBaPackage.BEHAVIOR_STATE__OUTGOING_TRANSITIONS, BehaviorState.class, msgs);
+        return basicSetSourceState((BehaviorState)otherEnd, msgs);
+      case AadlBaPackage.BEHAVIOR_TRANSITION__DESTINATION_STATE:
+        if (destinationState != null)
+          msgs = ((InternalEObject)destinationState).eInverseRemove(this, AadlBaPackage.BEHAVIOR_STATE__INCOMING_TRANSITIONS, BehaviorState.class, msgs);
+        return basicSetDestinationState((BehaviorState)otherEnd, msgs);
+    }
+    return super.eInverseAdd(otherEnd, featureID, msgs);
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  @Override
   public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs)
   {
     switch (featureID)
     {
+      case AadlBaPackage.BEHAVIOR_TRANSITION__SOURCE_STATE:
+        return basicSetSourceState(null, msgs);
       case AadlBaPackage.BEHAVIOR_TRANSITION__CONDITION:
         return basicSetCondition(null, msgs);
+      case AadlBaPackage.BEHAVIOR_TRANSITION__DESTINATION_STATE:
+        return basicSetDestinationState(null, msgs);
     }
     return super.eInverseRemove(otherEnd, featureID, msgs);
   }

--- a/org.osate.ba/src/org/osate/ba/aadlba/util/AadlBaAdapterFactory.java
+++ b/org.osate.ba/src/org/osate/ba/aadlba/util/AadlBaAdapterFactory.java
@@ -240,6 +240,11 @@ public class AadlBaAdapterFactory extends AdapterFactoryImpl
         return createClassifierFeatureHolderAdapter();
       }
       @Override
+      public Adapter caseClassifierFeaturePropertyReference(ClassifierFeaturePropertyReference object)
+      {
+        return createClassifierFeaturePropertyReferenceAdapter();
+      }
+      @Override
       public Adapter caseClassifierPropertyReference(ClassifierPropertyReference object)
       {
         return createClassifierPropertyReferenceAdapter();
@@ -253,11 +258,6 @@ public class AadlBaAdapterFactory extends AdapterFactoryImpl
       public Adapter caseCompletionRelativeTimeout(CompletionRelativeTimeout object)
       {
         return createCompletionRelativeTimeoutAdapter();
-      }
-      @Override
-      public Adapter caseClassifierFeaturePropertyReference(ClassifierFeaturePropertyReference object)
-      {
-        return createClassifierFeaturePropertyReferenceAdapter();
       }
       @Override
       public Adapter caseCondStatement(CondStatement object)
@@ -525,6 +525,21 @@ public class AadlBaAdapterFactory extends AdapterFactoryImpl
         return createPortSendActionAdapter();
       }
       @Override
+      public Adapter casePropertyAssociationHolder(PropertyAssociationHolder object)
+      {
+        return createPropertyAssociationHolderAdapter();
+      }
+      @Override
+      public Adapter casePropertyElementHolder(PropertyElementHolder object)
+      {
+        return createPropertyElementHolderAdapter();
+      }
+      @Override
+      public Adapter casePropertyExpressionHolder(PropertyExpressionHolder object)
+      {
+        return createPropertyExpressionHolderAdapter();
+      }
+      @Override
       public Adapter casePropertyNameField(PropertyNameField object)
       {
         return createPropertyNameFieldAdapter();
@@ -535,26 +550,6 @@ public class AadlBaAdapterFactory extends AdapterFactoryImpl
         return createPropertyNameHolderAdapter();
       }
       @Override
-      public Adapter casePropertyElementHolder(PropertyElementHolder object)
-      {
-        return createPropertyElementHolderAdapter();
-      }
-      @Override
-      public Adapter casePropertyAssociationHolder(PropertyAssociationHolder object)
-      {
-        return createPropertyAssociationHolderAdapter();
-      }
-      @Override
-      public Adapter casePropertyExpressionHolder(PropertyExpressionHolder object)
-      {
-        return createPropertyExpressionHolderAdapter();
-      }
-      @Override
-      public Adapter casePropertyTypeHolder(PropertyTypeHolder object)
-      {
-        return createPropertyTypeHolderAdapter();
-      }
-      @Override
       public Adapter casePropertyReference(PropertyReference object)
       {
         return createPropertyReferenceAdapter();
@@ -563,6 +558,11 @@ public class AadlBaAdapterFactory extends AdapterFactoryImpl
       public Adapter casePropertySetPropertyReference(PropertySetPropertyReference object)
       {
         return createPropertySetPropertyReferenceAdapter();
+      }
+      @Override
+      public Adapter casePropertyTypeHolder(PropertyTypeHolder object)
+      {
+        return createPropertyTypeHolderAdapter();
       }
       @Override
       public Adapter casePrototypeHolder(PrototypeHolder object)

--- a/org.osate.ba/src/org/osate/ba/aadlba/util/AadlBaSwitch.java
+++ b/org.osate.ba/src/org/osate/ba/aadlba/util/AadlBaSwitch.java
@@ -441,6 +441,20 @@ public class AadlBaSwitch<T> extends Switch<T>
         if (result == null) result = defaultCase(theEObject);
         return result;
       }
+      case AadlBaPackage.CLASSIFIER_FEATURE_PROPERTY_REFERENCE:
+      {
+        ClassifierFeaturePropertyReference classifierFeaturePropertyReference = (ClassifierFeaturePropertyReference)theEObject;
+        T result = caseClassifierFeaturePropertyReference(classifierFeaturePropertyReference);
+        if (result == null) result = casePropertyReference(classifierFeaturePropertyReference);
+        if (result == null) result = caseIntegerValueConstant(classifierFeaturePropertyReference);
+        if (result == null) result = caseValueConstant(classifierFeaturePropertyReference);
+        if (result == null) result = caseValue(classifierFeaturePropertyReference);
+        if (result == null) result = caseIntegerValue(classifierFeaturePropertyReference);
+        if (result == null) result = caseBehaviorElement(classifierFeaturePropertyReference);
+        if (result == null) result = caseElement(classifierFeaturePropertyReference);
+        if (result == null) result = defaultCase(theEObject);
+        return result;
+      }
       case AadlBaPackage.CLASSIFIER_PROPERTY_REFERENCE:
       {
         ClassifierPropertyReference classifierPropertyReference = (ClassifierPropertyReference)theEObject;
@@ -476,20 +490,6 @@ public class AadlBaSwitch<T> extends Switch<T>
         if (result == null) result = caseDispatchTriggerCondition(completionRelativeTimeout);
         if (result == null) result = caseBehaviorElement(completionRelativeTimeout);
         if (result == null) result = caseElement(completionRelativeTimeout);
-        if (result == null) result = defaultCase(theEObject);
-        return result;
-      }
-      case AadlBaPackage.CLASSIFIER_FEATURE_PROPERTY_REFERENCE:
-      {
-        ClassifierFeaturePropertyReference classifierFeaturePropertyReference = (ClassifierFeaturePropertyReference)theEObject;
-        T result = caseClassifierFeaturePropertyReference(classifierFeaturePropertyReference);
-        if (result == null) result = casePropertyReference(classifierFeaturePropertyReference);
-        if (result == null) result = caseIntegerValueConstant(classifierFeaturePropertyReference);
-        if (result == null) result = caseValueConstant(classifierFeaturePropertyReference);
-        if (result == null) result = caseValue(classifierFeaturePropertyReference);
-        if (result == null) result = caseIntegerValue(classifierFeaturePropertyReference);
-        if (result == null) result = caseBehaviorElement(classifierFeaturePropertyReference);
-        if (result == null) result = caseElement(classifierFeaturePropertyReference);
         if (result == null) result = defaultCase(theEObject);
         return result;
       }
@@ -1238,6 +1238,38 @@ public class AadlBaSwitch<T> extends Switch<T>
         if (result == null) result = defaultCase(theEObject);
         return result;
       }
+      case AadlBaPackage.PROPERTY_ASSOCIATION_HOLDER:
+      {
+        PropertyAssociationHolder propertyAssociationHolder = (PropertyAssociationHolder)theEObject;
+        T result = casePropertyAssociationHolder(propertyAssociationHolder);
+        if (result == null) result = casePropertyElementHolder(propertyAssociationHolder);
+        if (result == null) result = caseIndexableElement(propertyAssociationHolder);
+        if (result == null) result = caseBehaviorElement(propertyAssociationHolder);
+        if (result == null) result = caseElement(propertyAssociationHolder);
+        if (result == null) result = defaultCase(theEObject);
+        return result;
+      }
+      case AadlBaPackage.PROPERTY_ELEMENT_HOLDER:
+      {
+        PropertyElementHolder propertyElementHolder = (PropertyElementHolder)theEObject;
+        T result = casePropertyElementHolder(propertyElementHolder);
+        if (result == null) result = caseIndexableElement(propertyElementHolder);
+        if (result == null) result = caseBehaviorElement(propertyElementHolder);
+        if (result == null) result = caseElement(propertyElementHolder);
+        if (result == null) result = defaultCase(theEObject);
+        return result;
+      }
+      case AadlBaPackage.PROPERTY_EXPRESSION_HOLDER:
+      {
+        PropertyExpressionHolder propertyExpressionHolder = (PropertyExpressionHolder)theEObject;
+        T result = casePropertyExpressionHolder(propertyExpressionHolder);
+        if (result == null) result = casePropertyElementHolder(propertyExpressionHolder);
+        if (result == null) result = caseIndexableElement(propertyExpressionHolder);
+        if (result == null) result = caseBehaviorElement(propertyExpressionHolder);
+        if (result == null) result = caseElement(propertyExpressionHolder);
+        if (result == null) result = defaultCase(theEObject);
+        return result;
+      }
       case AadlBaPackage.PROPERTY_NAME_FIELD:
       {
         PropertyNameField propertyNameField = (PropertyNameField)theEObject;
@@ -1253,49 +1285,6 @@ public class AadlBaSwitch<T> extends Switch<T>
         T result = casePropertyNameHolder(propertyNameHolder);
         if (result == null) result = caseBehaviorElement(propertyNameHolder);
         if (result == null) result = caseElement(propertyNameHolder);
-        if (result == null) result = defaultCase(theEObject);
-        return result;
-      }
-      case AadlBaPackage.PROPERTY_ELEMENT_HOLDER:
-      {
-        PropertyElementHolder propertyElementHolder = (PropertyElementHolder)theEObject;
-        T result = casePropertyElementHolder(propertyElementHolder);
-        if (result == null) result = caseIndexableElement(propertyElementHolder);
-        if (result == null) result = caseBehaviorElement(propertyElementHolder);
-        if (result == null) result = caseElement(propertyElementHolder);
-        if (result == null) result = defaultCase(theEObject);
-        return result;
-      }
-      case AadlBaPackage.PROPERTY_ASSOCIATION_HOLDER:
-      {
-        PropertyAssociationHolder propertyAssociationHolder = (PropertyAssociationHolder)theEObject;
-        T result = casePropertyAssociationHolder(propertyAssociationHolder);
-        if (result == null) result = casePropertyElementHolder(propertyAssociationHolder);
-        if (result == null) result = caseIndexableElement(propertyAssociationHolder);
-        if (result == null) result = caseBehaviorElement(propertyAssociationHolder);
-        if (result == null) result = caseElement(propertyAssociationHolder);
-        if (result == null) result = defaultCase(theEObject);
-        return result;
-      }
-      case AadlBaPackage.PROPERTY_EXPRESSION_HOLDER:
-      {
-        PropertyExpressionHolder propertyExpressionHolder = (PropertyExpressionHolder)theEObject;
-        T result = casePropertyExpressionHolder(propertyExpressionHolder);
-        if (result == null) result = casePropertyElementHolder(propertyExpressionHolder);
-        if (result == null) result = caseIndexableElement(propertyExpressionHolder);
-        if (result == null) result = caseBehaviorElement(propertyExpressionHolder);
-        if (result == null) result = caseElement(propertyExpressionHolder);
-        if (result == null) result = defaultCase(theEObject);
-        return result;
-      }
-      case AadlBaPackage.PROPERTY_TYPE_HOLDER:
-      {
-        PropertyTypeHolder propertyTypeHolder = (PropertyTypeHolder)theEObject;
-        T result = casePropertyTypeHolder(propertyTypeHolder);
-        if (result == null) result = casePropertyElementHolder(propertyTypeHolder);
-        if (result == null) result = caseIndexableElement(propertyTypeHolder);
-        if (result == null) result = caseBehaviorElement(propertyTypeHolder);
-        if (result == null) result = caseElement(propertyTypeHolder);
         if (result == null) result = defaultCase(theEObject);
         return result;
       }
@@ -1323,6 +1312,17 @@ public class AadlBaSwitch<T> extends Switch<T>
         if (result == null) result = caseIntegerValue(propertySetPropertyReference);
         if (result == null) result = caseBehaviorElement(propertySetPropertyReference);
         if (result == null) result = caseElement(propertySetPropertyReference);
+        if (result == null) result = defaultCase(theEObject);
+        return result;
+      }
+      case AadlBaPackage.PROPERTY_TYPE_HOLDER:
+      {
+        PropertyTypeHolder propertyTypeHolder = (PropertyTypeHolder)theEObject;
+        T result = casePropertyTypeHolder(propertyTypeHolder);
+        if (result == null) result = casePropertyElementHolder(propertyTypeHolder);
+        if (result == null) result = caseIndexableElement(propertyTypeHolder);
+        if (result == null) result = caseBehaviorElement(propertyTypeHolder);
+        if (result == null) result = caseElement(propertyTypeHolder);
         if (result == null) result = defaultCase(theEObject);
         return result;
       }

--- a/org.osate.ba/src/org/osate/ba/parser/AadlBaParserVisitor.java
+++ b/org.osate.ba/src/org/osate/ba/parser/AadlBaParserVisitor.java
@@ -1014,6 +1014,7 @@ public class AadlBaParserVisitor<T> extends AbstractParseTreeVisitor<T>
       if(ctx.INITIAL() != null)
       {
         bs.setInitial(true) ;
+        ctx.ba.setInitialState(bs);
       }
       
       if(ctx.COMPLETE() != null)


### PR DESCRIPTION
* Added references from BehaviorState to BehaviorTransition (incoming and outgoing transitions)
  * no need for change in parser (references are automaticcaly filled through opposite mechanism)
* Added reference from BehaviorAnnex to initial BehaviorState
  * added a line in AadlBaParserVisitor.visitBehavior_state_list to fill the reference